### PR TITLE
Auto best quality for short non-playlist videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Backend: `yt-dlp` + `ffmpeg` + `aria2c` (khusus non‑YouTube).
     - `3` **720p** (prioritas **60fps**; fallback 30fps)
     - `4` **480p**
   - Subtitle yang dipilih **akan di-embed** ke video (jika tersedia di sumber).
+  - Video **non-playlist** dengan durasi **<1 menit** otomatis memakai resolusi terbaik tanpa submenu subtitle/resolusi.
 - **Downloader pintar**:
   - **YouTube** → downloader bawaan `yt-dlp` (**tanpa** aria2c) untuk kecepatan/stabilitas lebih baik.
   - **TikTok/Instagram/Twitter/Reddit/Bilibili** → **aria2c** koneksi moderat (`-x4 -s4`) agar stabil di Android.

--- a/termux-url-opener
+++ b/termux-url-opener
@@ -115,8 +115,14 @@ for url in "$@"; do
   else
     case "$choice" in
       1)  # NON-PLAYLIST → MP4
-        pick_subs
-        pick_res
+        DURATION=$(yt-dlp --no-playlist --print duration "$url" 2>/dev/null | head -n1 | cut -d. -f1)
+        if [ -n "$DURATION" ] && [ "$DURATION" -lt 60 ]; then
+          FMT="bestvideo+bestaudio/best"
+          SUB_OPTS=()
+        else
+          pick_subs
+          pick_res
+        fi
         yt-dlp --no-playlist \
           -f "$FMT" --merge-output-format mp4 \
           "${SUB_OPTS[@]}" \


### PR DESCRIPTION
## Summary
- auto-select highest resolution and skip subtitle menu for non-playlist videos under 1 minute
- document new behavior in README

## Testing
- `bash -n termux-url-opener`


------
https://chatgpt.com/codex/tasks/task_e_68c6141d84308321ae3ca7aa0ccf2e4c