### PR TITLE
Add Facebook, SoundCloud, and Twitch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Termux URL Downloader
 Mudah download video/audio via **Share → Termux** dari:
-**YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili**
+**YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, Twitch**
 
 Backend: `yt-dlp` + `ffmpeg` + `aria2c` (khusus non‑YouTube).
 
@@ -26,7 +26,7 @@ Backend: `yt-dlp` + `ffmpeg` + `aria2c` (khusus non‑YouTube).
   - Video **non-playlist** dengan durasi **<1 menit** otomatis memakai resolusi terbaik tanpa submenu subtitle/resolusi.
 - **Downloader pintar**:
   - **YouTube** → downloader bawaan `yt-dlp` (**tanpa** aria2c) untuk kecepatan/stabilitas lebih baik.
-  - **TikTok/Instagram/Twitter/Reddit/Bilibili** → **aria2c** koneksi moderat (`-x4 -s4`) agar stabil di Android.
+  - **TikTok/Instagram/Twitter/Reddit/Bilibili/Facebook/SoundCloud/Twitch** → **aria2c** koneksi moderat (`-x4 -s4`) agar stabil di Android.
 - **Folder keluaran rapi per situs**:
   - YouTube → `/sdcard/Movies/YouTube`
   - TikTok → `/sdcard/Movies/TikTok`
@@ -34,6 +34,9 @@ Backend: `yt-dlp` + `ffmpeg` + `aria2c` (khusus non‑YouTube).
   - Twitter/X → `/sdcard/Movies/Twitter`
   - Reddit → `/sdcard/Movies/Reddit`
   - Bilibili → `/sdcard/Movies/Bilibili`
+  - Facebook → `/sdcard/Movies/Facebook`
+  - SoundCloud → `/sdcard/Movies/SoundCloud`
+  - Twitch → `/sdcard/Movies/Twitch`
   - MP3 semua situs → `/sdcard/Music`
   - Thumbnail Only → `/sdcard/Pictures/Thumbnails`
 - **Cookies per situs** (opsional) untuk login/restricted:
@@ -42,6 +45,9 @@ Backend: `yt-dlp` + `ffmpeg` + `aria2c` (khusus non‑YouTube).
   - `/sdcard/Download/twitter_cookies.txt`
   - `/sdcard/Download/reddit_cookies.txt`
   - `/sdcard/Download/bilibili_cookies.txt`
+  - `/sdcard/Download/facebook_cookies.txt`
+  - `/sdcard/Download/soundcloud_cookies.txt`
+  - `/sdcard/Download/twitch_cookies.txt`
 
 ---
 
@@ -61,7 +67,7 @@ Installer akan:
 ---
 
 ## 📖 Cara Pakai
-1. Buka YouTube / TikTok / Instagram / Twitter / Reddit / Bilibili.
+1. Buka YouTube / TikTok / Instagram / Twitter / Reddit / Bilibili / Facebook / SoundCloud / Twitch.
 2. **Share → Termux**.
 3. Pilih:
    ```

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 # Installer untuk termux-url-opener (yt-dlp universal downloader)
-# Support: YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili
+# Support: YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, Twitch
 
 set -e
 
@@ -48,12 +48,15 @@ mkdir -p /sdcard/Movies/YouTube \
          /sdcard/Movies/Twitter \
          /sdcard/Movies/Reddit \
          /sdcard/Movies/Bilibili \
+         /sdcard/Movies/Facebook \
+         /sdcard/Movies/SoundCloud \
+         /sdcard/Movies/Twitch \
          /sdcard/Music \
          /sdcard/Pictures/Thumbnails
 
 echo "====================================="
 echo " ✅ Instalasi selesai!"
-echo " Share dari YouTube/TikTok/Instagram/Twitter/Reddit/Bilibili → Termux,"
+echo " Share dari YouTube/TikTok/Instagram/Twitter/Reddit/Bilibili/Facebook/SoundCloud/Twitch → Termux,"
 echo " lalu pilih MP4/MP3/Thumbnail."
 echo "====================================="
 

--- a/termux-url-opener
+++ b/termux-url-opener
@@ -1,6 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 # termux-url-opener : Share → Termux universal downloader
-# Sites: YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili
+# Sites: YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, Twitch
 # MP4 (subtitle→resolusi, tanpa embed thumbnail), MP3 (embed thumbnail), Thumbnail Only
 # Auto: aria2c OFF for YouTube, ON (x4) for others
 
@@ -19,6 +19,9 @@ IG_COOKIES="/sdcard/Download/instagram_cookies.txt"
 TW_COOKIES="/sdcard/Download/twitter_cookies.txt"
 RD_COOKIES="/sdcard/Download/reddit_cookies.txt"
 BB_COOKIES="/sdcard/Download/bilibili_cookies.txt"
+FB_COOKIES="/sdcard/Download/facebook_cookies.txt"
+SC_COOKIES="/sdcard/Download/soundcloud_cookies.txt"
+TC_COOKIES="/sdcard/Download/twitch_cookies.txt"
 
 # Folder output
 mkdir -p /sdcard/Movies/YouTube \
@@ -27,6 +30,9 @@ mkdir -p /sdcard/Movies/YouTube \
          /sdcard/Movies/Twitter \
          /sdcard/Movies/Reddit \
          /sdcard/Movies/Bilibili \
+         /sdcard/Movies/Facebook \
+         /sdcard/Movies/SoundCloud \
+         /sdcard/Movies/Twitch \
          /sdcard/Music \
          /sdcard/Pictures/Thumbnails
 
@@ -75,6 +81,12 @@ for url in "$@"; do
     OUT_MP4_BASE="/sdcard/Movies/Reddit";   [ -f "$RD_COOKIES" ] && COOKIE_OPT=(--cookies "$RD_COOKIES") || COOKIE_OPT=(); DOWNLOADER=(--downloader aria2c --downloader-args "$ARIA_ARGS")
   elif echo "$url" | grep -qi 'bilibili\.com'; then
     OUT_MP4_BASE="/sdcard/Movies/Bilibili"; [ -f "$BB_COOKIES" ] && COOKIE_OPT=(--cookies "$BB_COOKIES") || COOKIE_OPT=(); DOWNLOADER=(--downloader aria2c --downloader-args "$ARIA_ARGS")
+  elif echo "$url" | grep -qi 'facebook\.com'; then
+    OUT_MP4_BASE="/sdcard/Movies/Facebook"; [ -f "$FB_COOKIES" ] && COOKIE_OPT=(--cookies "$FB_COOKIES") || COOKIE_OPT=(); DOWNLOADER=(--downloader aria2c --downloader-args "$ARIA_ARGS")
+  elif echo "$url" | grep -qi 'soundcloud\.com'; then
+    OUT_MP4_BASE="/sdcard/Movies/SoundCloud"; [ -f "$SC_COOKIES" ] && COOKIE_OPT=(--cookies "$SC_COOKIES") || COOKIE_OPT=(); DOWNLOADER=(--downloader aria2c --downloader-args "$ARIA_ARGS")
+  elif echo "$url" | grep -qi 'twitch\.tv'; then
+    OUT_MP4_BASE="/sdcard/Movies/Twitch"; [ -f "$TC_COOKIES" ] && COOKIE_OPT=(--cookies "$TC_COOKIES") || COOKIE_OPT=(); DOWNLOADER=(--downloader aria2c --downloader-args "$ARIA_ARGS")
   elif echo "$url" | grep -qi 'youtu'; then
     OUT_MP4_BASE="/sdcard/Movies/YouTube";  [ -f "$YT_COOKIES" ] && COOKIE_OPT=(--cookies "$YT_COOKIES") || COOKIE_OPT=(); DOWNLOADER=()   # YouTube tanpa aria2c
   else


### PR DESCRIPTION
## Summary
- Extend downloader to handle Facebook, SoundCloud, and Twitch with site-specific folders and optional cookies
- Update documentation and installer for new platforms

## Testing
- `bash -n termux-url-opener`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c61dcfb064832199c02e60dc804d13