### PR TITLE
Add M4A audio option with embedded thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Backend: `yt-dlp` + `ffmpeg` + `aria2c` (khusus non‑YouTube).
   - `1` → **MP4** (pilih subtitle → pilih resolusi, **tanpa embed thumbnail**)
   - `2` → **WEBM** (pilih subtitle → pilih resolusi, **tanpa embed thumbnail**)
   - `3` → **MP3** (audio terbaik, **embed thumbnail** sebagai cover art)
-  - `4` → **Thumbnail Only** (gambar asli: jpg/png/webp)
+  - `4` → **M4A** (audio terbaik, **embed thumbnail** sebagai cover art)
+  - `5` → **Thumbnail Only** (gambar asli: jpg/png/webp)
 - **MP4/WEBM (Playlist & Non-playlist, urutan sama)**:
   - **Pilih subtitle**:
     - `1` Indonesia
@@ -38,7 +39,7 @@ Backend: `yt-dlp` + `ffmpeg` + `aria2c` (khusus non‑YouTube).
   - Facebook → `/sdcard/Movies/Facebook`
   - SoundCloud → `/sdcard/Movies/SoundCloud`
   - Twitch → `/sdcard/Movies/Twitch`
-  - MP3 semua situs → `/sdcard/Music`
+  - MP3/M4A semua situs → `/sdcard/Music`
   - Thumbnail Only → `/sdcard/Pictures/Thumbnails`
 - **Cookies per situs** (opsional) untuk login/restricted:
   - `/sdcard/Download/youtube_cookies.txt`
@@ -72,10 +73,11 @@ Installer akan:
 2. **Share → Termux**.
 3. Pilih:
    ```
-   1) MP4 (subtitle + resolusi)
-   2) WEBM (subtitle + resolusi)
-   3) MP3 (audio)
-   4) Thumbnail saja
+    1) MP4 (subtitle + resolusi)
+    2) WEBM (subtitle + resolusi)
+    3) MP3 (audio)
+    4) M4A (audio)
+    5) Thumbnail saja
    ```
 
 ### MP4/WEBM (Playlist & Non-playlist)
@@ -95,7 +97,7 @@ Installer akan:
   ```
 - **Catatan**: MP4/WEBM **tidak** meng-embed thumbnail. Hanya subtitle yang di-embed.
 
-### MP3
+### MP3/M4A
 - Diambil kualitas terbaik, **thumbnail di-embed** sebagai cover art.
 
 ### Thumbnail Only

--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,6 @@ mkdir -p /sdcard/Movies/YouTube \
 echo "====================================="
 echo " ✅ Instalasi selesai!"
 echo " Share dari YouTube/TikTok/Instagram/Twitter/Reddit/Bilibili/Facebook/SoundCloud/Twitch → Termux,"
-echo " lalu pilih MP4/MP3/Thumbnail."
+echo " lalu pilih MP4/WEBM/MP3/M4A/Thumbnail."
 echo "====================================="
 

--- a/termux-url-opener
+++ b/termux-url-opener
@@ -1,7 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 # termux-url-opener : Share → Termux universal downloader
 # Sites: YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, Twitch
-# MP4/WEBM (subtitle→resolusi, tanpa embed thumbnail), MP3 (embed thumbnail), Thumbnail Only
+# MP4/WEBM (subtitle→resolusi, tanpa embed thumbnail), MP3/M4A (embed thumbnail), Thumbnail Only
 # Auto: aria2c OFF for YouTube, ON (x4) for others
 
 set -e
@@ -114,8 +114,9 @@ for url in "$@"; do
   echo "1) MP4 (subtitle + resolusi)"
   echo "2) WEBM (subtitle + resolusi)"
   echo "3) MP3 (audio, embed thumbnail)"
-  echo "4) Thumbnail saja (format asli)"
-  read -r -p "Masukkan pilihan [1/2/3/4]: " choice
+  echo "4) M4A (audio, embed thumbnail)"
+  echo "5) Thumbnail saja (format asli)"
+  read -r -p "Masukkan pilihan [1/2/3/4/5]: " choice
 
   if is_playlist_url "$url"; then
     case "$choice" in
@@ -143,7 +144,13 @@ for url in "$@"; do
           -o "/sdcard/Music/%(playlist_title)s/%(playlist_index)03d - %(title).60s.%(ext)s" \
           "${DOWNLOADER[@]}" "${COOKIE_OPT[@]}" "$url"
         ;;
-      4)  # PLAYLIST → Thumbnail Only
+      4)  # PLAYLIST → M4A
+        yt-dlp --yes-playlist \
+          -x --audio-format m4a --audio-quality 0 --embed-thumbnail \
+          -o "/sdcard/Music/%(playlist_title)s/%(playlist_index)03d - %(title).60s.%(ext)s" \
+          "${DOWNLOADER[@]}" "${COOKIE_OPT[@]}" "$url"
+        ;;
+      5)  # PLAYLIST → Thumbnail Only
         yt-dlp --yes-playlist \
           --skip-download --write-thumbnail --convert-thumbnails "" \
           -o "/sdcard/Pictures/Thumbnails/%(playlist_title)s/%(playlist_index)03d - %(title).60s" \
@@ -189,7 +196,13 @@ for url in "$@"; do
           -o "/sdcard/Music/%(title).60s.%(ext)s" \
           "${DOWNLOADER[@]}" "${COOKIE_OPT[@]}" "$url"
         ;;
-      4)  # NON-PLAYLIST → Thumbnail Only
+      4)  # NON-PLAYLIST → M4A
+        yt-dlp --no-playlist \
+          -x --audio-format m4a --audio-quality 0 --embed-thumbnail \
+          -o "/sdcard/Music/%(title).60s.%(ext)s" \
+          "${DOWNLOADER[@]}" "${COOKIE_OPT[@]}" "$url"
+        ;;
+      5)  # NON-PLAYLIST → Thumbnail Only
         yt-dlp --no-playlist \
           --skip-download --write-thumbnail --convert-thumbnails "" \
           -o "/sdcard/Pictures/Thumbnails/%(title).60s" \


### PR DESCRIPTION
## Summary
- support downloading audio as M4A with embedded thumbnails
- document new M4A option across scripts and README

## Testing
- `bash -n termux-url-opener`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c623d6b5d48321a58a3837586972d4