### PR TITLE
Embed PNG cover art and convert thumbnails to JPEG

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Backend: `yt-dlp` + `ffmpeg` + `aria2c` (khusus non‑YouTube).
 - **Menu utama**:
   - `1` → **MP4** (pilih subtitle → pilih resolusi, **tanpa embed thumbnail**)
   - `2` → **WEBM** (pilih subtitle → pilih resolusi, **tanpa embed thumbnail**)
-  - `3` → **MP3** (audio terbaik, **embed thumbnail** sebagai cover art)
-  - `4` → **M4A** (audio terbaik, **embed thumbnail** sebagai cover art)
-  - `5` → **Thumbnail Only** (gambar asli: jpg/png/webp)
+  - `3` → **MP3** (audio terbaik, **embed thumbnail PNG** sebagai cover art)
+  - `4` → **M4A** (audio terbaik, **embed thumbnail PNG** sebagai cover art)
+  - `5` → **Thumbnail Only** (gambar disimpan sebagai **JPEG**)
 - **MP4/WEBM (Playlist & Non-playlist, urutan sama)**:
   - **Pilih subtitle**:
     - `1` Indonesia
@@ -98,10 +98,10 @@ Installer akan:
 - **Catatan**: MP4/WEBM **tidak** meng-embed thumbnail. Hanya subtitle yang di-embed.
 
 ### MP3/M4A
-- Diambil kualitas terbaik, **thumbnail di-embed** sebagai cover art.
+- Diambil kualitas terbaik, **thumbnail PNG di-embed** sebagai cover art.
 
 ### Thumbnail Only
-- Mengunduh **gambar asli** (jpg/png/webp), tanpa konversi.
+- Mengunduh thumbnail dan menyimpannya sebagai **JPEG**.
 
 ---
 

--- a/termux-url-opener
+++ b/termux-url-opener
@@ -1,7 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 # termux-url-opener : Share → Termux universal downloader
 # Sites: YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, Twitch
-# MP4/WEBM (subtitle→resolusi, tanpa embed thumbnail), MP3/M4A (embed thumbnail), Thumbnail Only
+# MP4/WEBM (subtitle→resolusi, tanpa embed thumbnail), MP3/M4A (embed PNG thumbnail), Thumbnail Only (JPEG)
 # Auto: aria2c OFF for YouTube, ON (x4) for others
 
 set -e
@@ -140,19 +140,19 @@ for url in "$@"; do
         ;;
       3)  # PLAYLIST → MP3
         yt-dlp --yes-playlist \
-          -x --audio-format mp3 --audio-quality 0 --embed-thumbnail \
+          -x --audio-format mp3 --audio-quality 0 --embed-thumbnail --convert-thumbnails png \
           -o "/sdcard/Music/%(playlist_title)s/%(playlist_index)03d - %(title).60s.%(ext)s" \
           "${DOWNLOADER[@]}" "${COOKIE_OPT[@]}" "$url"
         ;;
       4)  # PLAYLIST → M4A
         yt-dlp --yes-playlist \
-          -x --audio-format m4a --audio-quality 0 --embed-thumbnail \
+          -x --audio-format m4a --audio-quality 0 --embed-thumbnail --convert-thumbnails png \
           -o "/sdcard/Music/%(playlist_title)s/%(playlist_index)03d - %(title).60s.%(ext)s" \
           "${DOWNLOADER[@]}" "${COOKIE_OPT[@]}" "$url"
         ;;
       5)  # PLAYLIST → Thumbnail Only
         yt-dlp --yes-playlist \
-          --skip-download --write-thumbnail --convert-thumbnails "" \
+          --skip-download --write-thumbnail --convert-thumbnails jpg \
           -o "/sdcard/Pictures/Thumbnails/%(playlist_title)s/%(playlist_index)03d - %(title).60s" \
           "${COOKIE_OPT[@]}" "$url"
         ;;
@@ -192,19 +192,19 @@ for url in "$@"; do
         ;;
       3)  # NON-PLAYLIST → MP3
         yt-dlp --no-playlist \
-          -x --audio-format mp3 --audio-quality 0 --embed-thumbnail \
+          -x --audio-format mp3 --audio-quality 0 --embed-thumbnail --convert-thumbnails png \
           -o "/sdcard/Music/%(title).60s.%(ext)s" \
           "${DOWNLOADER[@]}" "${COOKIE_OPT[@]}" "$url"
         ;;
       4)  # NON-PLAYLIST → M4A
         yt-dlp --no-playlist \
-          -x --audio-format m4a --audio-quality 0 --embed-thumbnail \
+          -x --audio-format m4a --audio-quality 0 --embed-thumbnail --convert-thumbnails png \
           -o "/sdcard/Music/%(title).60s.%(ext)s" \
           "${DOWNLOADER[@]}" "${COOKIE_OPT[@]}" "$url"
         ;;
       5)  # NON-PLAYLIST → Thumbnail Only
         yt-dlp --no-playlist \
-          --skip-download --write-thumbnail --convert-thumbnails "" \
+          --skip-download --write-thumbnail --convert-thumbnails jpg \
           -o "/sdcard/Pictures/Thumbnails/%(title).60s" \
           "${COOKIE_OPT[@]}" "$url"
         ;;


### PR DESCRIPTION
## Summary
- Embed thumbnails as PNG cover art for MP3 and M4A downloads
- Save standalone thumbnails as JPEG files
- Update documentation to reflect new thumbnail formats

## Testing
- `apt-get update`
- `apt-get install -y shellcheck`
- `shellcheck termux-url-opener`
- `bash -n termux-url-opener`


------
https://chatgpt.com/codex/tasks/task_e_68c76872b91c83218d6fa9ed249e7e33