### PR TITLE
docs: add manual link invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Installer akan:
 ### MP4/WEBM (Playlist & Non-playlist)
 - Submenu **subtitle**:
   ```
-  1) Indonesia
+ 1) Indonesia
   2) English
   3) Japanese
   4) Tanpa subtitle
@@ -102,6 +102,21 @@ Installer akan:
 
 ### Thumbnail Only
 - Mengunduh thumbnail dan menyimpannya sebagai **JPEG**.
+
+### Manual (tanpa menu Share)
+Jika suatu aplikasi tidak menyediakan menu **Share → Termux** (contoh: playlist SoundCloud), salin URL dan jalankan skrip secara manual:
+
+```bash
+termux-url-opener 'https://soundcloud.com/user/sets/playlist-ku'
+```
+
+Jika URL sudah ada di clipboard:
+
+```bash
+termux-url-opener "$(termux-clipboard-get)"
+```
+
+Skrip akan memproses tautan tersebut seperti biasa.
 
 ---
 


### PR DESCRIPTION
## Summary
- document manual invocation if Share → Termux is unavailable

## Testing
- `bash -n termux-url-opener install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c77ef235808321a14614775a41cfc8