### PR TITLE
Convert social image downloads to JPEG via ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Backend: `yt-dlp` + `ffmpeg` + `aria2c` (khusus non‑YouTube).
   - `2` → **WEBM** (pilih subtitle → pilih resolusi, **tanpa embed thumbnail**)
   - `3` → **MP3** (audio terbaik, **embed thumbnail PNG** sebagai cover art)
   - `4` → **M4A** (audio terbaik, **embed thumbnail PNG** sebagai cover art)
-  - `5` → **Thumbnail Only** (gambar disimpan sebagai **JPEG**)
+  - `5` → **Thumbnail / Foto** (thumbnail video via `yt-dlp`, foto tunggal/carousel dikonversi ke **JPEG** via `ffmpeg`)
 - **MP4/WEBM (Playlist & Non-playlist, urutan sama)**:
   - **Pilih subtitle**:
     - `1` Indonesia
@@ -100,8 +100,11 @@ Installer akan:
 ### MP3/M4A
 - Diambil kualitas terbaik, **thumbnail PNG di-embed** sebagai cover art.
 
-### Thumbnail Only
-- Mengunduh thumbnail dan menyimpannya sebagai **JPEG**.
+### Thumbnail / Foto
+- Submenu:
+  - `1` Thumbnail video → `yt-dlp` mengekstrak gambar dari video dan menyimpannya sebagai **JPEG**.
+  - `2` Foto tunggal → diunduh (IG/Twitter dll.) lalu otomatis dikonversi ke **JPEG** oleh `ffmpeg`.
+  - `3` Carousel → seluruh slide foto diunduh lalu `ffmpeg` mengubah setiap file menjadi **JPEG**.
 
 ### Manual (tanpa menu Share)
 Jika suatu aplikasi tidak menyediakan menu **Share → Termux** (contoh: playlist SoundCloud), salin URL dan jalankan skrip secara manual:

--- a/termux-url-opener
+++ b/termux-url-opener
@@ -87,6 +87,9 @@ is_playlist_url() {
 # Aria2c konservatif
 ARIA_ARGS='aria2c:-x4 -s4 -k1M --file-allocation=none --summary-interval=0 --retry-wait=2 --max-tries=10'
 
+# Konversi otomatis foto → JPEG via ffmpeg (abaikan jika sudah JPEG)
+CONVERT_TO_JPEG_EXEC="sh -c 'in=\"\$1\"; ext=\"\${in##*.}\"; ext_lower=\$(printf \"%s\" \"\$ext\" | tr \"[:upper:]\" \"[:lower:]\"); if [ \"\$ext_lower\" = \"jpg\" ] || [ \"\$ext_lower\" = \"jpeg\" ]; then exit 0; fi; out=\"\${in%.*}.jpg\"; if ffmpeg -y -loglevel error -i \"\$in\" \"\$out\"; then rm -f \"\$in\"; fi' _ \"{}\""
+
 # Cookies (opsional)
 YT_COOKIES="/sdcard/Download/youtube_cookies.txt"
 IG_COOKIES="/sdcard/Download/instagram_cookies.txt"
@@ -334,12 +337,14 @@ for url in "$@"; do
             yt-dlp --no-playlist \
               -f "b/best" \
               -o "${OUT_IMG_BASE}/%(title).60s [%(id)s].%(ext)s" \
+              --exec "$CONVERT_TO_JPEG_EXEC" \
               "${DOWNLOADER[@]}" "${COOKIE_OPT[@]}" "$url"
             ;;
           carousel)
             yt-dlp --yes-playlist \
               -f "b/best" \
               -o "${OUT_IMG_BASE}/%(playlist_title|title|id)s/%(playlist_index|index|autonumber)02d - %(title|id)s.%(ext)s" \
+              --exec "$CONVERT_TO_JPEG_EXEC" \
               "${DOWNLOADER[@]}" "${COOKIE_OPT[@]}" "$url"
             ;;
         esac


### PR DESCRIPTION
## Summary
- add an ffmpeg-powered post-processing step so single and carousel image downloads are converted to JPEG while keeping yt-dlp for thumbnails
- document the updated image menu options and JPEG conversion flow in the README

## Testing
- bash -n termux-url-opener

------
https://chatgpt.com/codex/tasks/task_e_68ca76ae817083219febe103cb341030