### PR TITLE
Add Threads handling alongside Instagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Downloader berbasis Termux untuk menyimpan video atau audio langsung dari menu **Share → Termux**.
 
-**Didukung:** YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, dan Twitch.
+**Didukung:** YouTube, TikTok, Instagram, Threads, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, dan Twitch.
 
 **Backend utama:** `yt-dlp`, `gallery-dl` (foto), `ffmpeg`, serta `aria2c` untuk sumber non-YouTube.
 
@@ -30,7 +30,7 @@ Downloader berbasis Termux untuk menyimpan video atau audio langsung dari menu *
 ### Downloader pintar
 
 * **YouTube** menggunakan downloader bawaan `yt-dlp` (tanpa aria2c) demi kecepatan dan stabilitas.
-* **TikTok, Instagram, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, Twitch** memanfaatkan `aria2c` (`-x4 -s4`) agar lebih stabil di Android.
+* **TikTok, Instagram/Threads, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, Twitch** memanfaatkan `aria2c` (`-x4 -s4`) agar lebih stabil di Android.
 
 ### Struktur folder output
 
@@ -38,7 +38,7 @@ Downloader berbasis Termux untuk menyimpan video atau audio langsung dari menu *
 |--------|--------|
 | Video YouTube | `/sdcard/Movies/YouTube` |
 | Video TikTok | `/sdcard/Movies/TikTok` |
-| Video Instagram | `/sdcard/Movies/Instagram` |
+| Video Instagram / Threads | `/sdcard/Movies/Instagram` |
 | Video Twitter/X | `/sdcard/Movies/Twitter` |
 | Video Reddit | `/sdcard/Movies/Reddit` |
 | Video Bilibili | `/sdcard/Movies/Bilibili` |
@@ -53,7 +53,7 @@ Downloader berbasis Termux untuk menyimpan video atau audio langsung dari menu *
 | Situs | Path file |
 |-------|-----------|
 | YouTube | `/sdcard/Download/youtube_cookies.txt` |
-| Instagram | `/sdcard/Download/instagram_cookies.txt` |
+| Instagram / Threads | `/sdcard/Download/instagram_cookies.txt` |
 | Twitter/X | `/sdcard/Download/twitter_cookies.txt` |
 | Reddit | `/sdcard/Download/reddit_cookies.txt` |
 | Bilibili | `/sdcard/Download/bilibili_cookies.txt` |
@@ -85,7 +85,7 @@ Installer akan otomatis:
 
 ### Mode Share → Termux
 
-1. Buka salah satu aplikasi yang didukung (YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, atau Twitch).
+1. Buka salah satu aplikasi yang didukung (YouTube, TikTok, Instagram, Threads, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, atau Twitch).
 2. Pilih menu **Share → Termux**.
 3. Tentukan opsi yang diinginkan (lihat tabel menu utama di atas).
 

--- a/termux-url-opener
+++ b/termux-url-opener
@@ -1,6 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 # termux-url-opener : Share → Termux universal downloader
-# Sites: YouTube, TikTok, Instagram, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, Twitch
+# Sites: YouTube, TikTok, Instagram/Threads, Twitter/X, Reddit, Bilibili, Facebook, SoundCloud, Twitch
 # MP4/WEBM (subtitle→resolusi, tanpa embed thumbnail), MP3/M4A (embed PNG thumbnail), Thumbnail/Foto Only (JPEG)
 # Auto: aria2c OFF for YouTube, ON (x4) for others
 
@@ -270,7 +270,7 @@ for url in "$@"; do
   # Tentukan folder, cookies, & downloader
   if echo "$url" | grep -qi 'tiktok\.com'; then
     OUT_MP4_BASE="/sdcard/Movies/TikTok"; OUT_IMG_BASE="/sdcard/Pictures/TikTok"; set_cookie_opts ""; DOWNLOADER=(--downloader aria2c --downloader-args "$ARIA_ARGS")
-  elif echo "$url" | grep -qi 'instagram\.com'; then
+  elif echo "$url" | grep -qiE 'instagram\.com|threads\.net'; then
     OUT_MP4_BASE="/sdcard/Movies/Instagram"; OUT_IMG_BASE="/sdcard/Pictures/Instagram"; set_cookie_opts "$IG_COOKIES"; DOWNLOADER=(--downloader aria2c --downloader-args "$ARIA_ARGS")
   elif echo "$url" | grep -qiE 'twitter\.com|x\.com'; then
     OUT_MP4_BASE="/sdcard/Movies/Twitter";  OUT_IMG_BASE="/sdcard/Pictures/Twitter"; set_cookie_opts "$TW_COOKIES"; DOWNLOADER=(--downloader aria2c --downloader-args "$ARIA_ARGS")


### PR DESCRIPTION
## Summary
- treat threads.net URLs the same as instagram.com so they reuse the Instagram cookies and folders
- document Threads support across the README so users know it works like Instagram

## Testing
- bash -n termux-url-opener

------
https://chatgpt.com/codex/tasks/task_e_68ce216f96f08321bd41d6c6e2f52ae6